### PR TITLE
Fix GitHub Action

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/starwars/androidApp/MainActivity.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/starwars/androidApp/MainActivity.kt
@@ -42,6 +42,7 @@ sealed class Screen(val title: String) {
     object FilmList : Screen("Film List")
 }
 
+
 data class BottomNavigationitem(
     val route: String,
     val icon: ImageVector,

--- a/androidApp/src/main/java/dev/johnoreilly/starwars/androidApp/MainActivity.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/starwars/androidApp/MainActivity.kt
@@ -42,7 +42,6 @@ sealed class Screen(val title: String) {
     object FilmList : Screen("Film List")
 }
 
-
 data class BottomNavigationitem(
     val route: String,
     val icon: ImageVector,

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -67,6 +67,9 @@ android {
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
+        freeCompilerArgs = listOf(
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        )
     }
 }
 
@@ -76,7 +79,8 @@ val packForXcode by tasks.creating(Sync::class) {
     val mode = System.getenv("CONFIGURATION") ?: "DEBUG"
     val sdkName = System.getenv("SDK_NAME") ?: "iphonesimulator"
     val targetName = "ios" + if (sdkName.startsWith("iphoneos")) "Arm64" else "X64"
-    val framework = kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
+    val framework =
+        kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
     inputs.property("mode", mode)
     dependsOn(framework.linkTask)
     val targetDir = File(buildDir, "xcode-frameworks")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -79,8 +79,7 @@ val packForXcode by tasks.creating(Sync::class) {
     val mode = System.getenv("CONFIGURATION") ?: "DEBUG"
     val sdkName = System.getenv("SDK_NAME") ?: "iphonesimulator"
     val targetName = "ios" + if (sdkName.startsWith("iphoneos")) "Arm64" else "X64"
-    val framework =
-        kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
+    val framework = kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
     inputs.property("mode", mode)
     dependsOn(framework.linkTask)
     val targetDir = File(buildDir, "xcode-frameworks")


### PR DESCRIPTION
The GitHub Action fails because of ExperimentalCoroutinesAPI usages at the build iOS step. This PR resolves this issue by adding the necessary compiler arguments.