### PR TITLE
Move getAllPeopleMockResponse to using the test builders

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -93,4 +93,5 @@ apollo {
     packageName.set("dev.johnoreilly.starwars")
     codegenModels.set("operationBased")
     generateSchema.set(true)
+    generateTestBuilders.set(true)
 }

--- a/shared/src/commonTest/kotlin/dev/johnoreilly/starwars/shared/MockResponses.kt
+++ b/shared/src/commonTest/kotlin/dev/johnoreilly/starwars/shared/MockResponses.kt
@@ -1,20 +1,15 @@
 package dev.johnoreilly.starwars.shared
 
-import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.json.writeAny
 import com.apollographql.apollo3.api.json.writeObject
-import com.apollographql.apollo3.api.obj
-import dev.johnoreilly.starwars.GetAllPeopleQuery
-import dev.johnoreilly.starwars.adapter.GetAllPeopleQuery_ResponseAdapter
-import dev.johnoreilly.starwars.test.GetAllPeopleQuery_TestBuilder.Data
+import dev.johnoreilly.starwars.test.GetAllPeopleQuery_TestBuilder
 
 val getAllPeopleMockResponse = buildJsonString {
   writeObject {
     name("data")
-    GetAllPeopleQuery_ResponseAdapter.Data.obj().toJson(
-      writer = this,
-      customScalarAdapters = CustomScalarAdapters.Empty,
-      value = GetAllPeopleQuery.Data {
+    writeAny(
+      GetAllPeopleQuery_TestBuilder.DataBuilder().apply {
         allPeople = allPeople {
           people = listOf(
             person {
@@ -33,7 +28,7 @@ val getAllPeopleMockResponse = buildJsonString {
             }
           )
         }
-      }
+      }.build()
     )
   }
 }

--- a/shared/src/commonTest/kotlin/dev/johnoreilly/starwars/shared/MockResponses.kt
+++ b/shared/src/commonTest/kotlin/dev/johnoreilly/starwars/shared/MockResponses.kt
@@ -1,32 +1,42 @@
 package dev.johnoreilly.starwars.shared
 
-val getAllPeopleMockResponse = """
-    {
-      "data": {
-        "allPeople": {
-            "people": [
-            {
-                "__typename": "PeopleConnection",
-                "id": "cGVvcGxlOjE=",
-                "name": "Luke Skywalker",
-                "homeworld": {
-                    "name": "Tatooine"
-                }
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.json.writeObject
+import com.apollographql.apollo3.api.obj
+import dev.johnoreilly.starwars.GetAllPeopleQuery
+import dev.johnoreilly.starwars.adapter.GetAllPeopleQuery_ResponseAdapter
+import dev.johnoreilly.starwars.test.GetAllPeopleQuery_TestBuilder.Data
+
+val getAllPeopleMockResponse = buildJsonString {
+  writeObject {
+    name("data")
+    GetAllPeopleQuery_ResponseAdapter.Data.obj().toJson(
+      writer = this,
+      customScalarAdapters = CustomScalarAdapters.Empty,
+      value = GetAllPeopleQuery.Data {
+        allPeople = allPeople {
+          people = listOf(
+            person {
+              id = "cGVvcGxlOjE="
+              name = "Luke Skywalker"
+              homeworld = homeworld {
+                name = "Tatooine"
+              }
             },
-            {
-                "__typename": "PeopleConnection",
-                "id": "cGVvcGxlOjI=",
-                "name": "C-3PO",
-                "homeworld": {
-                    "name": "Tatooine"
-                }
-            }                      
-            ]
+            person {
+              id = "cGVvcGxlOjI="
+              name = "C-3PO"
+              homeworld = homeworld {
+                name = "Tatooine"
+              }
+            }
+          )
         }
       }
-    }
-  """.trimIndent()
-
+    )
+  }
+}
 
 val getAllFilmsMockResponse = """
     {
@@ -50,4 +60,5 @@ val getAllFilmsMockResponse = """
       }
     }
   """.trimIndent()
+
 


### PR DESCRIPTION
This is more verbose than needs be and also goes through the hoops of creating a `Data` to again serialize it but it's a type-safe way to create the mocked json until we improve the APIs