### PR TITLE
Update to Apollo Kotlin 5.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinx-coroutines = "1.11.0"
 androidGradlePlugin = "9.1.1"
 koin = "4.2.2"
 koinComposeMultiplatform = "4.2.2"
-apollo = "4.4.3"
+apollo = "5.0.1"
 apolloMockServer = "0.3.1"
 kmpNativeCoroutines = "1.0.5"
 

--- a/shared/src/commonMain/graphql/extra.graphqls
+++ b/shared/src/commonMain/graphql/extra.graphqls
@@ -1,26 +1,22 @@
-extend type Root @nonnull(fields: """
-allPeople
-allFilms
-""")
+extend schema @link(
+  url: "https://specs.apollo.dev/nullability/v0.4",
+  import: ["@semanticNonNull", "@semanticNonNullField", "@catch", "CatchTo", "@catchByDefault"]
+)
 
-extend type PeopleConnection @nonnull(fields: """
-people
-""")
+extend schema @catchByDefault(to: THROW)
 
-extend type Person @nonnull(fields: """
-name
-""")
+extend type Root
+  @semanticNonNullField(name: "allPeople")
+  @semanticNonNullField(name: "allFilms")
 
-extend type Planet @nonnull(fields: """
-name
-""")
+extend type PeopleConnection @semanticNonNullField(name: "people")
 
+extend type Person @semanticNonNullField(name: "name")
 
-extend type FilmsConnection @nonnull(fields: """
-films
-""")
+extend type Planet @semanticNonNullField(name: "name")
 
-extend type Film @nonnull(fields: """
-title
-director
-""")
+extend type FilmsConnection @semanticNonNullField(name: "films")
+
+extend type Film
+  @semanticNonNullField(name: "title")
+  @semanticNonNullField(name: "director")

--- a/shared/src/commonTest/kotlin/dev/johnoreilly/starwars/shared/MockResponses.kt
+++ b/shared/src/commonTest/kotlin/dev/johnoreilly/starwars/shared/MockResponses.kt
@@ -2,11 +2,12 @@ package dev.johnoreilly.starwars.shared
 
 import dev.johnoreilly.starwars.GetAllFilmsQuery
 import dev.johnoreilly.starwars.GetAllPeopleQuery
-import dev.johnoreilly.starwars.type.buildFilm
-import dev.johnoreilly.starwars.type.buildFilmsConnection
-import dev.johnoreilly.starwars.type.buildPeopleConnection
-import dev.johnoreilly.starwars.type.buildPerson
-import dev.johnoreilly.starwars.type.buildPlanet
+import dev.johnoreilly.starwars.builder.Data
+import dev.johnoreilly.starwars.builder.buildFilm
+import dev.johnoreilly.starwars.builder.buildFilmsConnection
+import dev.johnoreilly.starwars.builder.buildPeopleConnection
+import dev.johnoreilly.starwars.builder.buildPerson
+import dev.johnoreilly.starwars.builder.buildPlanet
 
 
 val getAllPeopleMockResponse = GetAllPeopleQuery.Data {


### PR DESCRIPTION
## Summary
Updates StarWars from Apollo Kotlin 4.4.3 to 5.0.1. Apollo 5 removes the client-side `@nonnull` directive and redesigns the data builders, so this required a real migration rather than a version-number bump:

- **`extra.graphqls`** — migrated `@nonnull(fields:)` to Apollo 5's semantic-nullability directives: `@link` the `nullability/v0.4` spec, set `@catchByDefault(to: THROW)` schema-wide, and mark each field with `@semanticNonNullField`. This keeps the fields generating as **non-null** (throwing on error), matching the previous behavior — so no changes were needed in `StarWarsRepository`.
- **`MockResponses.kt`** (test-only) — Apollo 5 moved the `buildX { }` data-builder helpers and the `Query.Data { }` DSL from the `.type` package into a new `.builder` package (now `DataBuilderScope` extensions); updated the imports.
- **`libs.versions.toml`** — `apollo = "4.4.3"` → `"5.0.1"`.

## Test plan
- [x] `./gradlew assembleDebug` (androidApp)
- [x] `./gradlew :server:assemble`
- [x] `./gradlew :compose-web:wasmJsBrowserDistribution`
- [x] `./gradlew :shared:compileKotlinIosArm64`
- [x] `./gradlew :shared:jvmTest`
- [x] `./gradlew :shared:iosSimulatorArm64Test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)